### PR TITLE
Upgrade `requests` to fix CVE-2018-18074

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v0.1.3] - 2018-10-30
+### Changed
+- Upgrade `requests` from `2.19.1` => `2.20.0` to address
+  security vulnerability [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)
+
+
 ## [v0.1.2] - 2018-07-18
 ### Added
 - Documentation in [Google style](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.19.1
+requests==2.20.0
 boto3==1.7.58


### PR DESCRIPTION
From `2.19.1` => `2.20.0` to address security vulnerability [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)

See GH alert: https://github.com/moj-analytical-services/pq_scraper/network/alert/requirements.txt/requests/open